### PR TITLE
Fix to use SNI when pulling certificate from server with multiple vhosts

### DIFF
--- a/src/Janus/OpenSsl/Command/SClient.php
+++ b/src/Janus/OpenSsl/Command/SClient.php
@@ -63,7 +63,7 @@ class Janus_OpenSsl_Command_SClient extends Janus_Shell_Command_Abstract
     {
         $command = self::COMMAND;
         if (isset($this->_connectTo)) {
-            $command .= " -connect {$this->_connectTo['host']}:{$this->_connectTo['port']}";
+            $command .= " -connect {$this->_connectTo['host']}:{$this->_connectTo['port']} -servername {$this->_connectTo['host']}";
         }
         if (isset($this->_showCerts) && $this->_showCerts) {
             $command .= ' -showcerts';


### PR DESCRIPTION
When connecting to a host that serves multiple (sub)-domains, the original command would return the certificate for the default or first-defined vhost. This leads to the wrong certificate being pulled, which in turn leads to a failing certificate check in Janus (see picture).

In the example below, I have connected an IdP (idp.moo-archive.nl) that is hosted on an Apache machine that serves multiple domains (idp.moo-archive.nl and demo.moo-archive.nl). The certificate-check incorrectly pulls the certificate for demo.moo-archive.nl from the server, because the command lacks the [SNI](https://en.wikipedia.org/wiki/Server_Name_Indication) parameter.

![naamloos](https://cloud.githubusercontent.com/assets/841045/19125017/bfdfa4f4-8b35-11e6-83dc-e1fe6d6e36f3.png)
